### PR TITLE
feat(schema): Use JSON type for protobuf google.protobuf.Struct

### DIFF
--- a/encoding/protobq/load_test.go
+++ b/encoding/protobq/load_test.go
@@ -7,11 +7,14 @@ import (
 	"cloud.google.com/go/bigquery"
 	"cloud.google.com/go/civil"
 	examplev1 "go.einride.tech/protobuf-bigquery/internal/examples/proto/gen/go/einride/bigquery/example/v1"
+	publicv1 "go.einride.tech/protobuf-bigquery/internal/examples/proto/gen/go/einride/bigquery/public/v1"
 	expr "google.golang.org/genproto/googleapis/api/expr/v1beta1"
 	"google.golang.org/genproto/googleapis/example/library/v1"
 	"google.golang.org/genproto/googleapis/type/datetime"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 	"gotest.tools/v3/assert"
 )
@@ -46,7 +49,54 @@ func TestUnmarshalOptions_Load(t *testing.T) {
 				Read:   true,
 			},
 		},
-
+		{
+			name: "publicv1.WhosOnFirstGeoJson",
+			row: []bigquery.Value{
+				"geoid",
+				int64(1192980459),
+				`{"lat": 76.16119999999999, "lon": 14.03075}`,
+				"Point",
+				"76.1612,14.03075,76.1612,14.03075",
+				"geonames",
+				int64(1536368481),
+				time.Date(2023, 1, 10, 0, 0, 0, 0, time.UTC),
+			},
+			schema: bigquery.Schema{
+				{Name: "geoid", Type: bigquery.StringFieldType},
+				{Name: "id", Type: bigquery.IntegerFieldType},
+				{Name: "body", Type: bigquery.JSONFieldType},
+				{Name: "geometry_type", Type: bigquery.StringFieldType},
+				{Name: "bounding_box", Type: bigquery.StringFieldType},
+				{Name: "geom", Type: bigquery.StringFieldType},
+				{Name: "last_modified", Type: bigquery.IntegerFieldType},
+				{Name: "last_modified_timestamp", Type: bigquery.TimestampFieldType},
+			},
+			expected: &publicv1.WhosOnFirstGeoJson{
+				Geoid: "geoid",
+				Id:    1192980459,
+				Body: &structpb.Struct{
+					Fields: map[string]*structpb.Value{
+						"lat": &structpb.Value{
+							Kind: &structpb.Value_NumberValue{
+								NumberValue: 76.16119999999999,
+							},
+						},
+						"lon": &structpb.Value{
+							Kind: &structpb.Value_NumberValue{
+								NumberValue: 14.03075,
+							},
+						},
+					},
+				},
+				GeometryType: "Point",
+				BoundingBox:  "76.1612,14.03075,76.1612,14.03075",
+				Geom:         "geonames",
+				LastModified: 1536368481,
+				LastModifiedTimestamp: &timestamppb.Timestamp{
+					Seconds: 1673308800,
+				},
+			},
+		},
 		{
 			name: "library.UpdateBookRequest",
 			row: []bigquery.Value{

--- a/encoding/protobq/schema.go
+++ b/encoding/protobq/schema.go
@@ -191,7 +191,7 @@ func (o SchemaOptions) inferFieldSchemaType(field protoreflect.FieldDescriptor) 
 		case wkt.BytesValue:
 			return bigquery.BytesFieldType
 		case wkt.Struct:
-			return bigquery.StringFieldType // JSON string
+			return bigquery.JSONFieldType
 		case wkt.Date:
 			return bigquery.DateFieldType
 		case wkt.DateTime:

--- a/encoding/protobq/schema.go
+++ b/encoding/protobq/schema.go
@@ -31,6 +31,8 @@ type SchemaOptions struct {
 	UseModeFromFieldBehavior bool
 	// UseProtoCommentsAsDescription use the proto comments to populate the description of the BigQuery field
 	UseProtoCommentsAsDescription bool
+	// UseJSONStructs use JSON type instead of string for STRUCT type
+	UseJSONStructs bool
 }
 
 // InferSchema infers a BigQuery schema for the given proto.Message using options in
@@ -191,7 +193,10 @@ func (o SchemaOptions) inferFieldSchemaType(field protoreflect.FieldDescriptor) 
 		case wkt.BytesValue:
 			return bigquery.BytesFieldType
 		case wkt.Struct:
-			return bigquery.JSONFieldType
+			if o.UseJSONStructs {
+				return bigquery.JSONFieldType
+			}
+			return bigquery.StringFieldType
 		case wkt.Date:
 			return bigquery.DateFieldType
 		case wkt.DateTime:

--- a/encoding/protobq/schema_test.go
+++ b/encoding/protobq/schema_test.go
@@ -292,6 +292,56 @@ func TestSchemaOptions_InferSchema(t *testing.T) {
 				},
 				{
 					Name:     "body",
+					Type:     bigquery.StringFieldType,
+					Required: false,
+				},
+				{
+					Name:     "geometry_type",
+					Type:     bigquery.StringFieldType,
+					Required: false,
+				},
+				{
+					Name:     "bounding_box",
+					Type:     bigquery.StringFieldType,
+					Required: false,
+				},
+				{
+					Name:     "geom",
+					Type:     bigquery.StringFieldType,
+					Required: false,
+				},
+				{
+					Name:     "last_modified",
+					Type:     bigquery.IntegerFieldType,
+					Required: false,
+				},
+				{
+					Name:     "last_modified_timestamp",
+					Type:     bigquery.TimestampFieldType,
+					Required: false,
+				},
+			},
+		},
+
+		{
+			name: "publicv1.WhosOnFirstGeoJson (with enable `UseJSONStructs`)",
+			opt: SchemaOptions{
+				UseJSONStructs: true,
+			},
+			msg: &publicv1.WhosOnFirstGeoJson{},
+			expected: bigquery.Schema{
+				{
+					Name:     "geoid",
+					Type:     bigquery.StringFieldType,
+					Required: false,
+				},
+				{
+					Name:     "id",
+					Type:     bigquery.IntegerFieldType,
+					Required: false,
+				},
+				{
+					Name:     "body",
 					Type:     bigquery.JSONFieldType,
 					Required: false,
 				},

--- a/encoding/protobq/schema_test.go
+++ b/encoding/protobq/schema_test.go
@@ -5,6 +5,7 @@ import (
 
 	"cloud.google.com/go/bigquery"
 	examplev1 "go.einride.tech/protobuf-bigquery/internal/examples/proto/gen/go/einride/bigquery/example/v1"
+	publicv1 "go.einride.tech/protobuf-bigquery/internal/examples/proto/gen/go/einride/bigquery/public/v1"
 	"google.golang.org/genproto/googleapis/example/library/v1"
 	"google.golang.org/protobuf/proto"
 	"gotest.tools/v3/assert"
@@ -270,6 +271,53 @@ func TestSchemaOptions_InferSchema(t *testing.T) {
 				{
 					Name:     "optional_int",
 					Type:     bigquery.IntegerFieldType,
+					Required: false,
+				},
+			},
+		},
+
+		{
+			name: "publicv1.WhosOnFirstGeoJson",
+			msg:  &publicv1.WhosOnFirstGeoJson{},
+			expected: bigquery.Schema{
+				{
+					Name:     "geoid",
+					Type:     bigquery.StringFieldType,
+					Required: false,
+				},
+				{
+					Name:     "id",
+					Type:     bigquery.IntegerFieldType,
+					Required: false,
+				},
+				{
+					Name:     "body",
+					Type:     bigquery.JSONFieldType,
+					Required: false,
+				},
+				{
+					Name:     "geometry_type",
+					Type:     bigquery.StringFieldType,
+					Required: false,
+				},
+				{
+					Name:     "bounding_box",
+					Type:     bigquery.StringFieldType,
+					Required: false,
+				},
+				{
+					Name:     "geom",
+					Type:     bigquery.StringFieldType,
+					Required: false,
+				},
+				{
+					Name:     "last_modified",
+					Type:     bigquery.IntegerFieldType,
+					Required: false,
+				},
+				{
+					Name:     "last_modified_timestamp",
+					Type:     bigquery.TimestampFieldType,
 					Required: false,
 				},
 			},

--- a/internal/examples/proto/gen/json/einride_bigquery_public_v1_whosonfirstgeojson.json
+++ b/internal/examples/proto/gen/json/einride_bigquery_public_v1_whosonfirstgeojson.json
@@ -13,7 +13,7 @@
   },
   {
     "name": "body",
-    "type": "STRING",
+    "type": "JSON",
     "mode": "NULLABLE",
     "description": "STRING NULLABLE"
   },

--- a/internal/examples/proto/gen/json/einride_bigquery_public_v1_whosonfirstgeojson.json
+++ b/internal/examples/proto/gen/json/einride_bigquery_public_v1_whosonfirstgeojson.json
@@ -13,7 +13,7 @@
   },
   {
     "name": "body",
-    "type": "JSON",
+    "type": "STRING",
     "mode": "NULLABLE",
     "description": "STRING NULLABLE"
   },


### PR DESCRIPTION
Currently `protobuf google.protobuf.Struct` will be inferred as bigquery STRING type. Since BQ already added native JSON support, it enable user to have more flexible access to JSON data and better cost efficiency compared to storing it as STRING. Main change on this PR only on infer the schema from proto, the rest like marshal and unmarshal still working as expected

Related issue: #257 