### PR TITLE
feat: remove warning when generating bq-json-schema

### DIFF
--- a/protoc-gen-bq-json-schema/main.go
+++ b/protoc-gen-bq-json-schema/main.go
@@ -5,6 +5,7 @@ import (
 
 	"go.einride.tech/protobuf-bigquery/protoc-gen-bq-json-schema/genjson"
 	"google.golang.org/protobuf/compiler/protogen"
+	"google.golang.org/protobuf/types/pluginpb"
 )
 
 func main() {
@@ -12,6 +13,7 @@ func main() {
 	var config genjson.Config
 	config.AddToFlagSet(flagSet)
 	protogen.Options{ParamFunc: flagSet.Set}.Run(func(gen *protogen.Plugin) error {
+		gen.SupportedFeatures = uint64(pluginpb.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL)
 		return genjson.Run(gen, config)
 	})
 }


### PR DESCRIPTION
Solves the warning bellow:

```
[proto:buf-generate] generating example proto stubs...
[proto:buf-generate] Warning: plugin "bq-json-schema" does not support required features.
[proto:buf-generate]   Feature "proto3 optional" is required by 1 file(s):
[proto:buf-generate]     einride/bigquery/example/v1/example_optional.proto
```