### PR TITLE
chore: bump sage and golint

### DIFF
--- a/.sage/go.mod
+++ b/.sage/go.mod
@@ -1,5 +1,5 @@
 module sage
 
-go 1.24.9
+go 1.25.7
 
-require go.einride.tech/sage v0.395.1
+require go.einride.tech/sage v0.410.0

--- a/.sage/go.sum
+++ b/.sage/go.sum
@@ -1,2 +1,2 @@
-go.einride.tech/sage v0.395.1 h1:x2MQrXq7+b66sndAP/Jn8ZFlPFYqn0wkKIylTHR317I=
-go.einride.tech/sage v0.395.1/go.mod h1:t5X6A8IrxcJV+HnP8mOo0fgvn3XgLu58C3DUMP6v35E=
+go.einride.tech/sage v0.410.0 h1:BdxcNbPNV4YCMPGSg2y3HtvtkRTx+P3cCFpXAD+I7+I=
+go.einride.tech/sage v0.410.0/go.mod h1:k/GWZv8EP64DxdCSZt9GIYMgOCxntdfE6FTRTIzQVdE=

--- a/.sage/sagefile.go
+++ b/.sage/sagefile.go
@@ -7,7 +7,7 @@ import (
 	"go.einride.tech/sage/tools/sgconvco"
 	"go.einride.tech/sage/tools/sggit"
 	"go.einride.tech/sage/tools/sggo"
-	"go.einride.tech/sage/tools/sggolangcilint"
+	"go.einride.tech/sage/tools/sggolangcilintv2"
 	"go.einride.tech/sage/tools/sgmdformat"
 	"go.einride.tech/sage/tools/sgyamlfmt"
 )
@@ -50,7 +50,7 @@ func GoTest(ctx context.Context) error {
 
 func GoLint(ctx context.Context) error {
 	sg.Logger(ctx).Println("linting Go files...")
-	return sggolangcilint.Run(ctx)
+	return sggolangcilintv2.Run(ctx, sggolangcilintv2.Config{})
 }
 
 func FormatMarkdown(ctx context.Context) error {

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ sagefile := $(abspath $(cwd)/.sage/bin/sagefile)
 go := $(shell command -v go 2>/dev/null)
 export GOWORK ?= off
 ifndef go
-SAGE_GO_VERSION ?= 1.24.12
+SAGE_GO_VERSION ?= 1.25.7
 export GOROOT := $(abspath $(cwd)/.sage/tools/go/$(SAGE_GO_VERSION)/go)
 export PATH := $(PATH):$(GOROOT)/bin
 go := $(GOROOT)/bin/go

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.einride.tech/protobuf-bigquery
 
-go 1.24.9
+go 1.25.7
 
 require (
 	cloud.google.com/go v0.123.0

--- a/internal/examples/proto/Makefile
+++ b/internal/examples/proto/Makefile
@@ -10,7 +10,7 @@ sagefile := $(abspath $(cwd)/../../../.sage/bin/sagefile)
 go := $(shell command -v go 2>/dev/null)
 export GOWORK ?= off
 ifndef go
-SAGE_GO_VERSION ?= 1.24.12
+SAGE_GO_VERSION ?= 1.25.7
 export GOROOT := $(abspath $(cwd)/../../../.sage/tools/go/$(SAGE_GO_VERSION)/go)
 export PATH := $(PATH):$(GOROOT)/bin
 go := $(GOROOT)/bin/go


### PR DESCRIPTION
If approved this PR:
* Bumps go version to `1.25.7`
* Bumps sage go version to `1.25.7`
* Bumps sage package to `v0.410.0`
* Changes linter from `sggolangcilint` to `sggolangcilintv2`